### PR TITLE
Fix integer type warnings in z85 divide by 85 macro

### DIFF
--- a/z85.c
+++ b/z85.c
@@ -44,7 +44,7 @@ typedef unsigned char byte;
 typedef char Z85_uint64_t_static_assert[sizeof(uint64_t) * CHAR_BIT == 64];
 typedef char Z85_uint32_t_static_assert[sizeof(uint32_t) * CHAR_BIT == 32];
 
-#define DIV85(number) ((uint32_t)(((uint64_t)3233857729 * number) >> 32) >> 6)
+#define DIV85(number) ((uint32_t)((3233857729ULL * number) >> 32) >> 6)
 
 static const char* base85 =
 {


### PR DESCRIPTION
The two warnings were generated while compiling on a 32bit ARM, they were:

warning: this decimal constant is unsigned only in ISO C90 [enabled by default]
warning: right shift count >= width of type [enabled by default]

They both originated from the fact that the 'number' in the macro was being
multiplied by a 64bit constant. However, the constant as defined was being
inferred as a signed 32bit int upon creation. This was solved by using the
'ULL' (unsigned long long) suffix with the value. A different fix might be to
use the UINT64_C macro which is defined in 'stdint.h'. But this would require
the removal of the custom uint32_t etc defines.
